### PR TITLE
Bind httpServer to 0.0.0.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func main() {
 
 		// Create HTTP server with origin validation middleware
 		httpServer := &http.Server{
-			Addr:    fmt.Sprintf("%s:%s", nomadURL.Hostname(), *port),
+			Addr:    fmt.Sprintf("%s:%s", "0.0.0.0", *port),
 			Handler: originValidationMiddleware(sseServer),
 		}
 


### PR DESCRIPTION
## 📑 Description
As it stands the httpServer tries to bind to the same address as Nomad which only works if it is deployed on the same host. 
I suspect we'd want some more functionality to enable setting the host but wanted to open the PR to get your opinion before making further changes.