### PR TITLE
fix: handle null timestamp fields

### DIFF
--- a/types/allocations.go
+++ b/types/allocations.go
@@ -30,10 +30,10 @@ type Allocation struct {
 
 // AllocDeploymentStatus represents the deployment status of an allocation
 type AllocDeploymentStatus struct {
-	Healthy     bool      `json:"Healthy"`
-	Timestamp   time.Time `json:"Timestamp"`
-	Canary      bool      `json:"Canary"`
-	ModifyIndex uint64    `json:"ModifyIndex"`
+	Healthy     bool       `json:"Healthy"`
+	Timestamp   *time.Time `json:"Timestamp"`
+	Canary      bool       `json:"Canary"`
+	ModifyIndex uint64     `json:"ModifyIndex"`
 }
 
 // RescheduleTracker represents the reschedule tracking information for an allocation
@@ -43,7 +43,7 @@ type RescheduleTracker struct {
 
 // RescheduleEvent represents a reschedule event
 type RescheduleEvent struct {
-	RescheduleTime time.Time `json:"RescheduleTime"`
-	PrevAllocID    string    `json:"PrevAllocID"`
-	PrevNodeID     string    `json:"PrevNodeID"`
+	RescheduleTime *time.Time `json:"RescheduleTime"`
+	PrevAllocID    string     `json:"PrevAllocID"`
+	PrevNodeID     string     `json:"PrevNodeID"`
 }

--- a/types/tasks.go
+++ b/types/tasks.go
@@ -8,8 +8,8 @@ import (
 type TaskState struct {
 	State      string      `json:"State"`
 	Failed     bool        `json:"Failed"`
-	StartedAt  time.Time   `json:"StartedAt"`
-	FinishedAt time.Time   `json:"FinishedAt"`
+	StartedAt  *time.Time  `json:"StartedAt"`
+	FinishedAt *time.Time  `json:"FinishedAt"`
 	Events     []TaskEvent `json:"Events"`
 }
 


### PR DESCRIPTION
## Problem
Timestamp fields couldn't handle null values from Nomad API, causing unmarshaling errors.

## Solution
Changed timestamp fields from `time.Time` to `*time.Time` pointers to properly handle null values:

- `StartedAt` and `FinishedAt` in `TaskState` 
- `Timestamp` in `AllocDeploymentStatus`
- `RescheduleTime` in `RescheduleEvent`

## Changes
- `/types/tasks.go`: Lines 11-12 - Changed to pointer types
- `/types/allocations.go`: Lines 34 & 46 - Changed to pointer types

## Testing
This fix allows the Go JSON unmarshaling to handle `null` values from the Nomad API without errors.

Fixes #22 