### PR TITLE
Honor standard NOMAD_CACERT, NOMAD_SKIP_VERIFY, and NOMAD_TLS_SERVER_NAME env vars

### DIFF
--- a/utils/client.go
+++ b/utils/client.go
@@ -4,11 +4,14 @@ package utils
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +50,9 @@ func NewNomadClient(address, token string) (*NomadClient, error) {
 		token:   token,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: buildTLSConfig(),
+			},
 		},
 		DefaultTailLines: 100, // Default to showing last 100 lines
 	}
@@ -1325,4 +1331,29 @@ func (c *NomadClient) ListAllocations() ([]types.Allocation, error) {
 	}
 
 	return allocations, nil
+}
+
+// buildTLSConfig constructs a *tls.Config from the standard NOMAD_* TLS environment
+// variables, matching the behavior of the official Nomad CLI and Go SDK.
+func buildTLSConfig() *tls.Config {
+	cfg := &tls.Config{}
+
+	if caFile := os.Getenv("NOMAD_CACERT"); caFile != "" {
+		if caPEM, err := os.ReadFile(caFile); err == nil {
+			pool := x509.NewCertPool()
+			if pool.AppendCertsFromPEM(caPEM) {
+				cfg.RootCAs = pool
+			}
+		}
+	}
+
+	if os.Getenv("NOMAD_SKIP_VERIFY") == "true" {
+		cfg.InsecureSkipVerify = true
+	}
+
+	if name := os.Getenv("NOMAD_TLS_SERVER_NAME"); name != "" {
+		cfg.ServerName = name
+	}
+
+	return cfg
 }


### PR DESCRIPTION
## Summary

The HTTP client in `utils/client.go` was constructed without a custom `Transport`, which meant the standard Nomad TLS environment variables were silently ignored:

- `NOMAD_CACERT`
- `NOMAD_SKIP_VERIFY`
- `NOMAD_TLS_SERVER_NAME`

Against any Nomad cluster using a self-signed or internal-CA certificate — which is the default for `nomad tls cert create` and most production setups — the server fails to connect with `x509: certificate is not trusted`, and there is no way for the user to provide trust material.

## The fix

Add a `buildTLSConfig()` helper that reads the same env vars as the official Nomad CLI and Go SDK, and wire the resulting `*tls.Config` into `httpClient.Transport`:

```go
httpClient: &http.Client{
    Timeout: 30 * time.Second,
    Transport: &http.Transport{
        TLSClientConfig: buildTLSConfig(),
    },
},
```

```go
func buildTLSConfig() *tls.Config {
    cfg := &tls.Config{}

    if caFile := os.Getenv("NOMAD_CACERT"); caFile != "" {
        if caPEM, err := os.ReadFile(caFile); err == nil {
            pool := x509.NewCertPool()
            if pool.AppendCertsFromPEM(caPEM) {
                cfg.RootCAs = pool
            }
        }
    }

    if os.Getenv("NOMAD_SKIP_VERIFY") == "true" {
        cfg.InsecureSkipVerify = true
    }

    if name := os.Getenv("NOMAD_TLS_SERVER_NAME"); name != "" {
        cfg.ServerName = name
    }

    return cfg
}
```

## Testing

Tested against a Nomad cluster with a `nomad-agent-ca.pem`-signed server certificate (the default output of `nomad tls cert create`).

| | Before patch | After patch |
|---|---|---|
| `NOMAD_CACERT` set, valid CA | ❌ `certificate is not trusted` | ✅ Connects |
| `NOMAD_SKIP_VERIFY=true` | ❌ `certificate is not trusted` | ✅ Connects |
| No TLS env vars, system-trusted CA | ✅ Connects | ✅ Connects |
| No TLS env vars, untrusted CA | ❌ Fails | ❌ Fails *(unchanged)* |

End-to-end verified with Claude Code via stdio MCP transport against a real Nomad cluster — `list_jobs`, `get_job_status`, and allocation log retrieval all work correctly over verified TLS.

## Related

This matches the documented behavior of the [official Nomad CLI environment variables](https://developer.hashicorp.com/nomad/docs/runtime/environment) and the [`nomadapi.TLSConfig`](https://pkg.go.dev/github.com/hashicorp/nomad/api#TLSConfig) struct in the Go SDK.