### PR TITLE
Build with patched Go toolchain

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.2'
+          go-version: '1.26.2'
 
       - name: Install goreleaser
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21, 1.22, 1.23]
+        go-version: [1.26.2]
 
     steps:
     - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.23
+        go-version: 1.26.2
 
     - name: Install dependencies
       run: |
@@ -85,7 +85,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.23
+        go-version: 1.26.2
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kocierik/mcp-nomad
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/mark3labs/mcp-go v0.49.0


### PR DESCRIPTION
Updates the module and CI/release workflows to use Go 1.26.2, which contains fixes for the standard-library vulnerabilities reported by govulncheck against Go 1.26.0.

Why:
- `govulncheck ./...` reported reachable vulnerabilities in `crypto/x509`, `crypto/tls`, and `net/url` when the project was scanned/built with Go 1.26.0.
- The release workflow was pinned to Go 1.24.2, and the test workflow still used 1.21/1.22/1.23 even though `go.mod` already required a newer Go line.

Changes:
- Set `go 1.26.2` in `go.mod`.
- Align test, benchmark, lint, and release workflows on Go 1.26.2.

Verification:
- `go test ./...` passes.
- `govulncheck ./...` reports `No vulnerabilities found.`