### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kocierik/mcp-nomad/security/code-scanning/4](https://github.com/kocierik/mcp-nomad/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit least-privilege token access by default.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this is best:
- Minimal, safe default for this CI workflow (checkout/tests/lint/security scanning).
- Applies to all current jobs (`test`, `benchmark`, `lint`, `security`) without duplicating config.
- Preserves behavior while satisfying CodeQL’s requirement for explicit token scoping.

No imports/methods/dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
